### PR TITLE
Use builtin Rust cfg options to enforce x84_64 targets only

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,3 @@ path = "src/lib.rs"
 
 [dependencies]
 ykstackmaps = { git = "https://github.com/softdevteam/ykstackmaps" }
-static_assertions = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,4 @@
+#![cfg(not(all( target_pointer_width = "64", target_arch = "x86_64")))]
+compile_error!("Requires x86_64 with 64 bit pointer width.");
+
 pub mod safepoints;

--- a/src/safepoints.rs
+++ b/src/safepoints.rs
@@ -1,4 +1,3 @@
-use static_assertions::assert_eq_size;
 use std::{collections::HashMap, path::Path};
 use ykstackmaps::{LocKind, LocOffset, SMRec, StackMapParser};
 
@@ -119,9 +118,6 @@ fn gen_safepoint_roots(stackmap: SMRec) -> SafepointRoots {
 /// and generate an efficient hashmap -- keyed by a function's return address --
 /// which can be queried by the collector.
 pub fn gen_safepoint_table<P: AsRef<Path>>(path: P) -> HashMap<ReturnAddress, SafepointRoots> {
-    // Ensure that this is used only on 64 bit architecture.
-    assert_eq_size!(u64, usize);
-
     let parser = StackMapParser::new(path.as_ref()).unwrap();
 
     let mut frames = HashMap::new();


### PR DESCRIPTION
Speaks for itself, but means we no longer need a dependency for `static_assertions`.