### PR TITLE
Implement a basic bump-pointer allocator

### DIFF
--- a/src/collector.rs
+++ b/src/collector.rs
@@ -13,9 +13,6 @@ use crate::{
 /// The size of the heap in bytes
 const HSIZE: usize = 1024;
 
-/// The byte alignment of the heap
-const HALIGN: usize = 4;
-
 pub(crate) struct Collector {
     hptr: Cell<*mut usize>,
     hstart: Cell<usize>,
@@ -48,8 +45,8 @@ impl Collector {
         self.collect_next.get()
     }
 
-    pub fn mk_heap(&self) {
-        let layout = Layout::from_size_align(HSIZE, HALIGN).unwrap();
+    pub fn mk_heap(&self, size: usize) {
+        let layout = Layout::array::<u8>(size).unwrap();
         let ptr = unsafe { alloc(layout) as *mut usize };
 
         if ptr.is_null() {
@@ -58,7 +55,7 @@ impl Collector {
 
         self.hptr.set(ptr);
         self.hstart.set(ptr as usize);
-        self.hend.set(ptr as usize + HSIZE);
+        self.hend.set(ptr as usize + size);
     }
 
     pub fn mk_root_table<P: AsRef<Path>>(&self, path: P) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,8 @@
 //!     roots: HashMap<ReturnAddress, SafepointRoots>
 //! }
 
+#![feature(alloc_layout_extra)]
+
 #[cfg(not(all(target_pointer_width = "64", target_arch = "x86_64")))]
 compile_error!("Requires x86_64 with 64 bit pointer width.");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ pub trait Scan {
     fn scan(&self) {}
 }
 
+#[derive(Debug)]
 pub enum GcErr {
     OOM(String),
 }


### PR DESCRIPTION
This is the very first stage of allocation. I've made this PR as small as possible because there's quite a lot of fiddly details coming up. This is a basic allocator which simply increments the pointer by the size of the last stored object until the heap runs out of memory. 